### PR TITLE
removed the neccesity of sudo during dependency installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,7 @@
 echo "## This script will install dependencies for BitbucketToGithub"
-echo "## run with 'sudo' if it doesn't work"
 echo ""
 echo ""
 
-pip3 install requests
-pip3 install pprintpp
-pip3 install pygithub
+pip3 install --user requests
+pip3 install --user pprintpp
+pip3 install --user pygithub


### PR DESCRIPTION
Adding of sudo during a pip installation seems harmless practice at first but granting pip during the installation is basically giving access to your whole machine to an internet code.

https://stackoverflow.com/questions/21055859/what-are-the-risks-of-running-sudo-pip